### PR TITLE
Use photos-picker instead of photos as directory in Dropbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ More details [here](doc/filters.md)
 Note that uploaders don't append new photos. Either the directory must be empty or the uploader clear it before copying files.
 
 * `FilesystemUploader`: copy the photos to a given directory. This directory must exist and be empty.
-* `DropBoxUploader`: upload the photos to Dropbox. ***Be careful, the script empty the `/photos` directory, you must limit your token access to application for avoiding unwanted deletions***.
+* `DropBoxUploader`: upload the photos to Dropbox. Note that you should limit your token access to application. Creating a full access token is not needed and may induce security issues.
 
 More details [here](doc/uploaders.md)
 

--- a/photospicker/uploader/dropbox_uploader.py
+++ b/photospicker/uploader/dropbox_uploader.py
@@ -19,7 +19,7 @@ class DropboxUploader(AbstractUploader):
         """Clear remote directory"""
         # Clear application directory
         try:
-            self._dbx.files_delete_v2('/photos')
+            self._dbx.files_delete_v2('/photos-picker')
         except ApiError as e:
             if not isinstance(e.error, DeleteError) \
                     or not e.error.is_path_lookup():
@@ -33,7 +33,7 @@ class DropboxUploader(AbstractUploader):
         :param str original_filename: original file name
         """
         # Upload file
-        path = "/photos/{photo_name}".format(
+        path = "/photos-picker/{photo_name}".format(
             photo_name=self._build_filename(original_filename)
         )
         self._dbx.files_upload(binary, path)

--- a/tests/uploader/test_dropbox_uploader.py
+++ b/tests/uploader/test_dropbox_uploader.py
@@ -25,7 +25,7 @@ class TestDropboxUploader(TestCase):
         dropbox_uploader = DropboxUploader(None)
         dropbox_uploader.initialize()
 
-        dropbox_mock.files_delete_v2.assert_called_once_with('/photos')
+        dropbox_mock.files_delete_v2.assert_called_once_with('/photos-picker')
 
     @mock.patch('photospicker.uploader.dropbox_uploader.Dropbox')
     def test_upload(self, dropbox_constructor_mock):
@@ -47,8 +47,8 @@ class TestDropboxUploader(TestCase):
 
         dropbox_constructor_mock.assert_called_with('mytoken')
         dropbox_mock.files_upload.assert_has_calls([
-            mock.call('mybinarydata', '/photos/photo1.png'),
-            mock.call('mybinarydata2', '/photos/photo2.jpg')
+            mock.call('mybinarydata', '/photos-picker/photo1.png'),
+            mock.call('mybinarydata2', '/photos-picker/photo2.jpg')
         ])
 
     @mock.patch('photospicker.uploader.dropbox_uploader.Dropbox')
@@ -97,5 +97,5 @@ class TestDropboxUploader(TestCase):
         dropbox_uploader.upload('mybinarydata', 'myphoto.png')
         dropbox_mock.files_upload.assert_called_with(
             'mybinarydata',
-            '/photos/photo0.png'
+            '/photos-picker/photo0.png'
         )


### PR DESCRIPTION
(more secure since photos-picker empty it)