### PR TITLE
Check that target directory exists and is empty before scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add CHANGELOG.md
 * Add SmartPicker
 * Take care that photos to retrieve count is not greater than total photos count (at AbstractPicker level)
+* On FilesystemUploader, check that target directory exists and is empty before scanning
 
 # 0.3.1
 * Allow to use a custom target directory in Dropbox

--- a/photospicker/uploader/filesystem_uploader.py
+++ b/photospicker/uploader/filesystem_uploader.py
@@ -6,7 +6,14 @@ import os
 class FilesystemUploader(AbstractUploader):
     """Copy picked photo to a filesystem empty directory"""
 
-    def initialize(self):  # pragma: no cover
+    def __init__(self, folder_path):
+        """
+        Constructor
+
+        :param str folder_path: target folder path
+        """
+        super(FilesystemUploader, self).__init__(folder_path)
+
         """Check target directory"""
         if not os.path.isdir(self._path):
             raise UploaderException(
@@ -19,6 +26,9 @@ class FilesystemUploader(AbstractUploader):
                 UploaderException.NOT_EMPTY,
                 "Directory {path} not empty".format(path=self._path)
             )
+
+    def initialize(self):
+        pass
 
     def upload(self, binary, original_filename):
         """

--- a/tests/uploader/test_filesystem_uploader.py
+++ b/tests/uploader/test_filesystem_uploader.py
@@ -10,7 +10,7 @@ class TestFilesystemUploader(TestCase):
 
     @mock.patch('os.listdir')
     @mock.patch('os.path.isdir')
-    def test_initialize_directory_not_found(self, is_dir_mock, listdir_mock):
+    def test_constructor_directory_not_found(self, is_dir_mock, listdir_mock):
         """
         Test that an exception is launched if the directory is not found
 
@@ -20,8 +20,7 @@ class TestFilesystemUploader(TestCase):
         is_dir_mock.return_value = False
 
         with self.assertRaises(UploaderException) as cm:
-            sut = FilesystemUploader('/root/myfolder')
-            sut.initialize()
+            FilesystemUploader('/root/myfolder')
 
         is_dir_mock.assert_called_with('/root/myfolder')
 
@@ -29,7 +28,7 @@ class TestFilesystemUploader(TestCase):
 
     @mock.patch('os.listdir')
     @mock.patch('os.path.isdir')
-    def test_initialize_directory_not_empty(self, is_dir_mock, listdir_mock):
+    def test_constructor_directory_not_empty(self, is_dir_mock, listdir_mock):
         """
         Test that an exception is launched if the directory is not empty
 
@@ -40,8 +39,7 @@ class TestFilesystemUploader(TestCase):
         listdir_mock.return_value = ['myfile']
 
         with self.assertRaises(UploaderException) as cm:
-            sut = FilesystemUploader('/root/myfolder')
-            sut.initialize()
+            FilesystemUploader('/root/myfolder')
 
         is_dir_mock.assert_called_with('/root/myfolder')
         listdir_mock.assert_called_with('/root/myfolder')


### PR DESCRIPTION
Closes #46 